### PR TITLE
Added all sup. elements for trailing comma rule

### DIFF
--- a/src/PhpCsFixer.php
+++ b/src/PhpCsFixer.php
@@ -41,7 +41,14 @@ class PhpCsFixer
             ],
             'function_typehint_space' => true,
             'ordered_imports' => true,
-            'trailing_comma_in_multiline' => ['after_heredoc' => false],
+            'trailing_comma_in_multiline' => [
+                'after_heredoc' => false,
+                'elements' => [
+                    'arguments',
+                    'arrays',
+                    'parameters',
+                ],
+            ],
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'new_line_for_chained_calls',
             ],


### PR DESCRIPTION
The trailing_comma_in_multiline rule adds trailing commas per default just on arrays.

Because the currently installed php-cs-fixer version does not yet support "match" as an element, only "arguments" and "paramters" were included in addition to the default "arrays".