### PR TITLE
Test assertion and trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,8 +564,8 @@ write readable tests.
 
 As a team, we agreed that the order in which the assertion functions are
 declared is also important. In the tests in the Arrange section, we always start
-with the providing with assertions and their mocks first. This is followed by
-the expects assertions before the initialization of the class under test. Mocks
+with the providing with/without assertions and their mocks. Followed by the
+expects assertions before the initialization of the class under test. Mocks
 that have with/without & expects assertions are an exception. If they occur,
 they should be placed between the with/without assertions and the expects
 assertions. Again, the with and without assertions are defined on the mock

--- a/README.md
+++ b/README.md
@@ -621,4 +621,109 @@ private function expectsPriceCalculatedInfoLog(
 }
 ```
 
+## Trailing commas
+
+Based on PER Coding Styles 2.0, we use trailing commas for related multiline
+statements such as function parameters, function calls, and arrays.
+
+This gives us several advantages. The first advantage is probably a bit
+surprising at first glance: we get a more consistent and clearer syntax. For all
+related multiline statements, there is only one rule - indent and append a
+comma. Not like before, where this rule applied to all lines except the last.
+Without a trailing comma, it is more difficult for colleagues, one of whom adds
+trailing commas and the other does not, as well as for code style fixers who
+have to correct a more complex set of rules.
+
+Another advantage of trailing commas is that it simplifies versioning and code
+review. When additional lines are added using trailing commas, there is only one
+diff on one line instead of two lines.
+
+**Bad array**
+
+```php
+$handbags = [
+    'Hermes Birkin',
+    'Chanel 2.55',
+    'Louis Vuitton Speedy'
+];
+```
+
+**Good array**
+
+```php
+$handbags = [
+    'Hermes Birkin',
+    'Chanel 2.55',
+    'Louis Vuitton Speedy',
+];
+```
+
+**Bad function declaration**
+
+```php
+/**
+ * @param string ...$other
+ */
+function compareHandbags(
+    string $handbag,
+    ...$other
+) {
+    // compare logic
+}
+```
+
+**Good function declaration**
+
+```php
+/**
+ * @param string ...$other
+ */
+function compareHandbags(
+    string $handbag,
+    ...$other,
+) {
+    // compare logic
+}
+```
+
+**Bad function call**
+
+```php
+compareHandbags(
+    'Prada Galleria',
+    'Dior Saddle',
+    'Gucci Dionysus'
+);
+```
+
+**Good function call**
+
+```php
+compareHandbags(
+    'Prada Galleria',
+    'Dior Saddle',
+    'Gucci Dionysus',
+);
+```
+
+**Bad match**
+
+```php
+$recommendation = match ($userPreference) {
+    'classic' => 'Chanel 2.55',
+    'modern' => 'Stella McCartney Falabella',
+    'versatile' => 'Louis Vuitton Neverfull'
+};
+```
+
+**Good match**
+
+```php
+$recommendation = match ($userPreference) {
+    'classic' => 'Chanel 2.55',
+    'modern' => 'Stella McCartney Falabella',
+    'versatile' => 'Louis Vuitton Neverfull',
+};
+```
+
 more CleanCode principles: https://github.com/piotrplenik/clean-code-php

--- a/README.md
+++ b/README.md
@@ -417,6 +417,44 @@ $invoice->setBillingAddress(
 );
 ```
 
+### Long strings - an exception
+
+However, we do not apply this rule to long strings. The reason for this is that
+breaking long strings into several short strings makes them much harder to find,
+especially when it comes to log messages. For practical reasons, we refrain
+from using more readable and accessible code at this point.
+
+**Bad**
+
+```php
+private function doSomething(Some $thing, string $callerId): void
+{
+    $this->logger->info(
+        'Something really important happented within {something}, triggered'
+        . 'from caller {callerId}',
+        [
+            'something' => $thing->getName(),
+            'callerId' => $callerId,
+        ],
+    );
+}
+```
+
+**Good**
+
+```php
+private function doSomething(Some $thing, string $callerId): void
+{
+    $this->logger->info(
+        'Something really important happented within {something}, triggered from caller {callerId}',
+        [
+            'something' => $thing->getName(),
+            'callerId' => $callerId,
+        ],
+    );
+}
+```
+
 ## Unit tests
 
 Unit tests are to be set up according to the AAA pattern, whereby the areas are

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # PHP Codestyle
 
-The tasko Codestyle is based on the [PSR-12](https://www.php-fig.org/psr/psr-12/) guidlines with some addtions.
+The tasko Codestyle is based on the
+[PSR-12](https://www.php-fig.org/psr/psr-12/) guidlines with some addtions.
 
 ## Every new PHP file has to have header
-This block of code provides information about the copyright and license of the code and declares strict typing.
+This block of code provides information about the copyright and license of the
+code and declares strict typing.
+
 ```php
 <?php
 /**
@@ -12,17 +15,21 @@ This block of code provides information about the copyright and license of the c
  */
 
 declare(strict_types=1);
-
 ```
 4 spaces by `copyright` and 6 spaces by `license`
 
 ## Comment Your Code
 
-This doesn't mean that you start commenting everywhere in your code and create a huge load of unwanted comments. If you do so then your failing to express the code you had written to other developers.
+This doesn't mean that you start commenting everywhere in your code and create a
+huge load of unwanted comments. If you do so then your failing to express the
+code you had written to other developers.
 
-Comment whenever it's necessary, when you have some complicated code or expression so that developers and you at later point will understand what you were trying to achieve.
+Comment whenever it's necessary, when you have some complicated code or
+expression so that developers and you at later point will understand what you
+were trying to achieve.
 
-### Bad
+**Bad**
+
 ```php
 /** Get the user details */
 public function getUserSalary(int $id): string 
@@ -43,7 +50,7 @@ private function currentMonthSalary(User $user): void
 }
 ```
 
-### Better
+**Good**
 
 ```php
 public function getUserSalary(int $id): void
@@ -59,18 +66,17 @@ private function currentMonthSalary(User $user): string
     /** Salary = (Total Days - Leave Days) * PerDay Salary */
     // ...
 }
-
 ```
 
 ## Use Meaningful & Pronounceable Variable Names
 
-### Bad
+**Bad**
 
 ```php
 $ymdstr = date('d-M-Y', strtotime($customer->created_at));
 ```
 
-### Good
+**Good**
 
 ```php
 $customerRegisteredDate = date('d-M-Y', strtotime($customer->created_at));
@@ -78,7 +84,8 @@ $customerRegisteredDate = date('d-M-Y', strtotime($customer->created_at));
 
 ## Use Proper & Meaningful Method Names
 
-### Bad
+**Bad**
+
 ```php
 public function user($email): void
 {
@@ -86,7 +93,8 @@ public function user($email): void
 }
 ```
 
-### Good
+**Good**
+
 ```php
 public function getUserDetailsByEmail($email): array
 {
@@ -96,9 +104,11 @@ public function getUserDetailsByEmail($email): array
 
 ## Readable & Searchable Code
 
-Try to use CONSTANTS or Functions for more readable & searchable code. This helps you very much in a longer run
+Try to use CONSTANTS or Functions for more readable & searchable code. This
+helps you very much in a longer run
 
-### Bad
+**Bad**
+
 ```php
 // What the heck is 1 & 2 for?
 if ($user->gender == 1) {
@@ -109,7 +119,9 @@ if ($user->gender == 2) {
     // ...
 }
 ```
-### Good
+
+**Good**
+
 ```php
 public const MALE = 1;
 public const FEMALE = 2;
@@ -124,18 +136,32 @@ if ($user->gender === FEMALE) {
 ```
 
 ## Avoid Deep Nesting & Return Early
+
 Avoid deep nesting as much as possible and use early returns.
-Deep nesting, also known as excessive nesting, occurs when multiple levels of indentation are used in code to represent a complex control flow. While nesting is sometimes necessary for creating complex algorithms, it is generally best to avoid excessive nesting in your coding style for the following reasons:
+Deep nesting, also known as excessive nesting, occurs when multiple levels of
+indentation are used in code to represent a complex control flow. While nesting
+is sometimes necessary for creating complex algorithms, it is generally best to
+avoid excessive nesting in your coding style for the following reasons:
 
-+ Decreased readability: When code is excessively nested, it can be difficult to read and understand. This can lead to errors, especially when other developers need to read or modify your code.
-+ Increased complexity: Excessive nesting can make code more complex than it needs to be. This can make it harder to maintain, debug, and test.
-+ Reduced performance: Excessive nesting can reduce performance, as each level of nesting requires additional processing time. This may not be noticeable in small applications, but it can have a significant impact on larger applications.
-+ Higher risk of errors: Deeply nested code is more error-prone, as it can be difficult to keep track of all the conditions and logic. This can lead to bugs, unexpected results, and security vulnerabilities.
++ Decreased readability: When code is excessively nested, it can be difficult to
+read and understand. This can lead to errors, especially when other developers
+need to read or modify your code.
++ Increased complexity: Excessive nesting can make code more complex than it
+needs to be. This can make it harder to maintain, debug, and test.
++ Reduced performance: Excessive nesting can reduce performance, as each level
+of nesting requires additional processing time. This may not be noticeable in
+small applications, but it can have a significant impact on larger applications.
++ Higher risk of errors: Deeply nested code is more error-prone, as it can be
+difficult to keep track of all the conditions and logic. This can lead to bugs,
+unexpected results, and security vulnerabilities.
 
-To avoid excessive nesting, you can use techniques like early return, guard clauses, and flattening conditional statements. These techniques can help simplify your code, make it more readable, and reduce the risk of errors:
+To avoid excessive nesting, you can use techniques like early return, guard
+clauses, and flattening conditional statements. These techniques can help
+simplify your code, make it more readable, and reduce the risk of errors:
 
 ### 1) <ins>Early Return</ins>:
-### Bad
+**Bad**
+
 ```php
 public function calculatePrice($quantity, $pricePerUnit): float {
     $price = 0;
@@ -150,7 +176,8 @@ public function calculatePrice($quantity, $pricePerUnit): float {
 }
 ```
 
-### Good
+**Good**
+
 ```php
 public function calculatePrice($quantity, $pricePerUnit): float {
     if ($quantity <= 0) {
@@ -165,8 +192,10 @@ public function calculatePrice($quantity, $pricePerUnit): float {
     return $price;
 }
 ```
+
 ### 2) <ins>Guard Clauses</ins>:
-### Bad
+**Bad**
+
 ```php
 public function calculateTax($price, $taxRate): int {
     $tax = 0;
@@ -176,9 +205,10 @@ public function calculateTax($price, $taxRate): int {
     
     return $tax;
 }
-
 ```
-### Good
+
+**Good**
+
 ```php
 public function calculateTax($price, $taxRate): int {
     if ($price <= 0) {
@@ -187,10 +217,11 @@ public function calculateTax($price, $taxRate): int {
     
     return $price * $taxRate;    
 }
-
 ```
+
 ### 3) <ins>Flattening Conditional Statements</ins>:
-### Bad
+**Bad**
+
 ```php
 if ($user->isAdmin()) {
     if ($user->isSuperAdmin()) {
@@ -203,9 +234,10 @@ if ($user->isAdmin()) {
 else {
     // do something different
 }
-
 ```
-### Good
+
+**Good**
+
 ```php
 if ($user->isSuperAdmin()) {
     // do something
@@ -217,27 +249,38 @@ else {
     // do something different
 }
 ```
+
 ## Avoid Useless Variables As Much As Possible
-<b>Basically if you use the variable more than 2 times in a code then keep that variable else directly use it inside the code.</b> This improves the readability and makes your code cleaner.
-### Bad
+
+**Basically if you use the variable more than 2 times in a code then keep that
+variable else directly use it inside the code.** This improves the readability
+and makes your code cleaner.
+
+**Bad**
+
 ```php
 public function addNumbers($a, $b): int {
     $result = $a + $b;
     $finalResult = $result * 2; // Useless variable
     return $finalResult;
 }
-
 ```
-### Good
+
+**Good**
+
 ```php
 public function addNumbers($a, $b): int {
     return ($a + $b) * 2; // Directly use the expression
 }
-
 ```
+
 ## Null Coalescing Operator ( ?? )
-Null Coalescing operator checks if the variable or the condition was empty or not.
-### Bad
+
+Null Coalescing operator checks if the variable or the condition was empty or
+not.
+
+**Bad**
+
 ```php
 if (!empty($user)) {
   return $user;
@@ -245,14 +288,19 @@ if (!empty($user)) {
 
 return false;
 ```
-### Good
+
+**Good**
+
 ```php
 return $user ?? false;
 ```
 
 ## Comparison (===, !==)
-### Bad
+
+**Bad**
+
 The simple comparison will convert the string in an integer.
+
 ```php
 $a = '7';
 $b = 7;
@@ -261,10 +309,14 @@ if ($a != $b) {
     // The expression will always pass
 }
 ```
-The comparison $a != $b returns FALSE but in fact it's TRUE! The string 7 is different from the integer 7.
 
-### Good
+The comparison $a != $b returns FALSE but in fact it's TRUE! The string 7 is
+different from the integer 7.
+
+**Good**
+
 The identical comparison will compare type and value.
+
 ```php
 $a = '7';
 $b = 7;
@@ -273,33 +325,45 @@ if ($a !== $b) {
     // The expression is verified
 }
 ```
+
 The comparison $a !== $b returns TRUE.
 
 ## Null check
-### Good
-It is a good habit to check for nullable variables using the `null === $variable` format:
+
+**Good**
+
+It is a good habit to check for nullable variables using the
+`null === $variable` format:
+
 ```php
 if (null === $variable) {
     // code here
 }
 ```
-This format helps to prevent <ins><b>accidental</b></ins> assignment of null values to variables such as:
+
+This format helps to prevent <ins>**accidental**</ins> assignment of null
+values to variables such as:
+
 ```php
 if ($variable = null) {
     
 }
 ```
 
-
 ## Encapsulate Conditionals
-Writing conditions is not bad but if you encapsulate into methods/functions then it will help better readability and maintain code in the future.
-### Bad
+Writing conditions is not bad but if you encapsulate into methods/functions then
+it will help better readability and maintain code in the future.
+
+**Bad**
+
 ```php
 if ($article->status === 'published') {
     // ...
 }
 ```
-### Good
+
+**Good**
+
 ```php
 if ($article->isPublished()) {
     // ...
@@ -308,18 +372,22 @@ if ($article->isPublished()) {
 
 ## Use an IDE ruler of 80 characters
 If a line of code exceeds 80 characters, use the line-breaks accordingly:
-### Bad
+
+**Bad**
+
 ```php
     private function expectOrderFromUri(MockInterface $someService, SomeOtherClass $otherClass, Order $order): void {
         $someService->expects()->getOrderByUri($otherClass->getResource()->getUri())->andReturns($order);
     }
 ```
-### Good
+
+**Good**
+
 ```php
     private function expectOrderFromUri(
         MockInterface $someService,
         SomeOtherClass $otherClass,
-        Order $order
+        Order $order,
     ): void {
         $someService
             ->expects()
@@ -328,10 +396,18 @@ If a line of code exceeds 80 characters, use the line-breaks accordingly:
         ;
     }
 ```
-The use of line breaks and indentation in the second function makes the code more readable and easier to understand, especially when dealing with longer method chains.
-Pay attention, that in this example semicolon is placed on the new line to make it more visible, where is the end fo this chained code expression.
 
-When using the nullsafe operator (or some other) in a chained method, it is necessary to begin the new line with the operator. This ensures that the operator is properly applied to the previous method call in the chain. 
+The use of line breaks and indentation in the second function makes the code
+more readable and easier to understand, especially when dealing with longer
+method chains.
+
+Pay attention, that in this example semicolon is placed on the new line to make
+it more visible, where is the end fo this chained code expression.
+
+When using the nullsafe operator (or some other) in a chained method, it is
+necessary to begin the new line with the operator. This ensures that the
+operator is properly applied to the previous method call in the chain.
+
 ```php
 // Set the billing address for an invoice
 $invoice->setBillingAddress(

--- a/README.md
+++ b/README.md
@@ -376,25 +376,25 @@ If a line of code exceeds 80 characters, use the line-breaks accordingly:
 **Bad**
 
 ```php
-    private function withOrderFromUri(\Mockery\MockInterface $someService, SomeOtherClass $otherClass, Order $order): void {
-        $someService->expects()->getOrderByUri($otherClass->getResource()->getUri())->andReturns($order);
-    }
+private function withOrderFromUri(\Mockery\MockInterface $someService, SomeOtherClass $otherClass, Order $order): void {
+    $someService->expects()->getOrderByUri($otherClass->getResource()->getUri())->andReturns($order);
+}
 ```
 
 **Good**
 
 ```php
-    private function withOrderFromUri(
-        \Mockery\MockInterface $someService,
-        SomeOtherClass $otherClass,
-        Order $order,
-    ): void {
-        $someService
-            ->expects()
-            ->getOrderByUri($otherClass->getResource()->getUri())
-            ->andReturns($order)
-        ;
-    }
+private function withOrderFromUri(
+    \Mockery\MockInterface $someService,
+    SomeOtherClass $otherClass,
+    Order $order,
+): void {
+    $someService
+        ->expects()
+        ->getOrderByUri($otherClass->getResource()->getUri())
+        ->andReturns($order)
+    ;
+}
 ```
 
 The use of line breaks and indentation in the second function makes the code
@@ -476,7 +476,7 @@ public function testCalculateTotalPriceForArticles(): void
             'A total price {totalPrice} has been calculated, including a tax portion of {taxRate}%',
             [
                 'totalPrice' => 51.1581,
-                'taxRate' => 0.19
+                'taxRate' => 0.19,
             ],
         )
     ;
@@ -523,7 +523,7 @@ public function testCalculateTotalPriceForArticles(): void
             'A total price {totalPrice} has been calculated, including a tax portion of {taxRate}%',
             [
                 'totalPrice' => 51.1581,
-                'taxRate' => 0.19
+                'taxRate' => 0.19,
             ],
         )
     ;
@@ -614,7 +614,7 @@ private function expectsPriceCalculatedInfoLog(
             'A total price {totalPrice} has been calculated, including a tax portion of {taxRate}%',
             [
                 'totalPrice' => 51.1581,
-                'taxRate' => 0.19
+                'taxRate' => 0.19,
             ],
         )
     ;


### PR DESCRIPTION
The PHP style guides have been refactored and brought into a consistent form, including the 80 ruler, which of course also affects markdown files.

Two new sections have been added:
1. a section on unit testing and Tasko's assertion functions
2. and a section on trailing commas in related multi-line statements